### PR TITLE
feat(ui): replay slice B browser copy shortcuts and payload

### DIFF
--- a/app/browser_view.h
+++ b/app/browser_view.h
@@ -119,11 +119,18 @@ private:
 
     // JSON parsing (reuses extractJsonStringField pattern)
     static std::string extractJsonStringField(const std::string& json, const std::string& key);
+    static std::vector<std::string> extractJsonStringValues(const std::string& json, const std::string& key);
+    void refreshCopyPayload(const std::string& rawJson);
 
     // Draw helpers
     void drawUrlBar();
     void drawStatusBar();
     void drawKeyHints();
+    void copyPageToClipboard();
+
+    // Cached source markdown + extracted image source URLs for clipboard copy.
+    std::string latestMarkdown;
+    std::vector<std::string> latestImageUrls;
 };
 
 // Factory function

--- a/app/test_pattern_app.cpp
+++ b/app/test_pattern_app.cpp
@@ -1687,6 +1687,8 @@ TMenuBar* TTestPatternApp::initMenuBar(TRect r)
             newLine() +
             *new TMenuItem("E~x~it", cmQuit, cmQuit, hcNoContext, "Alt-X") +
         *new TSubMenu("~E~dit", kbAltE) +
+            *new TMenuItem("~C~opy Page", cmCopy, kbCtrlIns) +
+            newLine() +
             *new TMenuItem("Sc~r~eenshot", cmScreenshot, kbCtrlP) +
             newLine() +
             (TMenuItem&) (

--- a/tests/contract/test_browser_copy_ui_contract.py
+++ b/tests/contract/test_browser_copy_ui_contract.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_browser_view_has_copy_shortcuts_and_handler() -> None:
+    source = Path("app/browser_view.cpp").read_text(encoding="utf-8")
+
+    assert "case kbCtrlIns:" in source
+    assert "case 'y':" in source
+    assert "event.message.command == cmCopy" in source
+    assert "copyPageToClipboard()" in source
+
+
+def test_browser_copy_payload_prefers_markdown_and_image_urls() -> None:
+    source = Path("app/browser_view.cpp").read_text(encoding="utf-8")
+    header = Path("app/browser_view.h").read_text(encoding="utf-8")
+
+    assert "latestMarkdown" in header
+    assert "latestImageUrls" in header
+    assert "refreshCopyPayload(fetchBuffer)" in source
+    assert "extractJsonStringValues" in source
+    assert "flattenMarkdownLinks" in source
+    assert "\"source_url\"" in source
+
+
+def test_edit_menu_wires_copy_page_command() -> None:
+    source = Path("app/test_pattern_app.cpp").read_text(encoding="utf-8")
+    assert "~C~opy Page" in source
+    assert "cmCopy" in source


### PR DESCRIPTION
## Summary
Slice B of recovery replay from `codex-e001-s01-registry-skeleton` onto fresh `main`.

Ports browser copy UX + payload behavior:
- Browser keyboard copy shortcuts (`Ctrl+Ins`, `y`) and `cmCopy` dispatch.
- Markdown-first clipboard payload in browser window copy path.
- Multiline markdown link flattening for copy safety/readability.
- Append deduplicated full `source_url` image URLs to copied content.
- Wire `Edit -> Copy Page` menu entry.

## Evidence
- Recovery issue: #44
- Branch: `rescue/e002-slice-b-browser-copy`
- Commit: `321e1c4`

## Tests
- `tools/api_server/venv/bin/python -m pytest -q tests/contract/test_browser_copy_ui_contract.py tests/contract/test_screenshot_api.py tests/contract/test_browser_ai_tools.py`
- Result: `7 passed, 2 skipped`

## Rollback
1. Revert commit `321e1c4`.
2. Verify browser copy behavior returns to prior plain-text-only flow.
3. Re-run listed contract tests.

## Links
- Follow-on slices tracked in #44.
