### PR TITLE
E013 deferred: AC-11/12 title persistence + F06 parity script

### DIFF
--- a/.codex-logs/2026-02-23/ac1112-titles-160911.log
+++ b/.codex-logs/2026-02-23/ac1112-titles-160911.log
@@ -1,0 +1,592 @@
+OpenAI Codex v0.53.0 (research preview)
+--------
+workdir: /Users/james/Repos/wibandwob-dos
+model: gpt-5.2-codex
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: auto
+session id: 019c8b43-088d-7123-bea9-b6ced4cbacae
+--------
+user
+DEVNOTE: Files inside .codex-logs/ are run logs — ignore them completely.
+EFFICIENCY: Use rg -n -C3 or sed -n 'N,Mp'. Never dump full files.
+
+Task: implement window title persistence for frame_player workspace save/restore (issue #84, AC-11/AC-12).
+
+Context:
+- Workspace save: buildWorkspaceJson() in app/test_pattern_app.cpp
+- Workspace restore: loadWorkspaceFromFile() in app/test_pattern_app.cpp
+- frame_player windows (TFrameAnimationWindow) currently save title: "" because w->getTitle() returns empty string
+- TFrameAnimationWindow has getFilePath() which returns the full file path
+- The top-level "title" field in the workspace JSON is the right place (not props)
+
+Find the frame_player save block in buildWorkspaceJson (search for type == "frame_player" near buildWorkspaceJson).
+The JSON builder writes something like: << ",\"title\":\"" then calls w->getTitle().
+For frame_player: if w->getTitle() is empty, derive title from getFilePath() stem:
+  e.g. "modules-private/wibwobworld/primers/cat-in-space.txt" → "cat-in-space"
+
+Two places need changing:
+
+1. WHERE TITLE IS WRITTEN IN THE JSON (in buildWorkspaceJson, near the title serialisation):
+   Find where the code writes the window title to JSON. For frame_player windows,
+   if the title is empty, substitute the filename stem derived from getFilePath().
+   Use existing jsonEscape() helper. Pattern: basename = last path component, strip extension.
+
+2. WHERE frame_player IS RESTORED (in loadWorkspaceFromFile, the frame_player case):
+   Currently: openAnimationFilePath(path, bounds, false, false);
+   The function signature is: openAnimationFilePath(path, bounds, frameless, shadowless, title="")
+   Parse the top-level "title" string from the workspace JSON object (use parseKeyedString
+   on the top-level obj, not inside props). Pass it to openAnimationFilePath.
+
+Steps:
+1. rg -n 'getTitle\|title.*json\|json.*title' app/test_pattern_app.cpp | head -20
+   Find where title is written in buildWorkspaceJson
+2. rg -n 'openAnimationFilePath' app/test_pattern_app.cpp
+   Find the restore call site
+3. Make both changes
+4. cmake --build ./build --target test_pattern -j4 2>&1 | grep -E "error:|Linking"
+5. Verify no errors
+
+Do not change props. Do not touch gallery or text_view cases.
+
+thinking
+**Planning agent location**
+
+I'm prioritizing finding the agents first to build an efficient command-based approach.
+exec
+rg -n --files -g AGENTS.md . in /Users/james/Repos/wibandwob-dos succeeded in 63ms:
+./AGENTS.md
+exec
+cat AGENTS.md in /Users/james/Repos/wibandwob-dos succeeded in 27ms:
+# AGENTS.md (Codex Prompt-Shim)
+
+This file aligns Codex execution style with the repo canon in `.planning/README.md` and the guardrails encoded in `.claude/hooks/*`.
+
+## Important: Hooks vs Codex
+
+Codex does not natively execute Claude Code hook scripts.  
+Treat the rules below as a required prompt-shim and manual gate before finishing work.
+Mirror high-value hook behavior explicitly, including `.claude/hooks/gh-format-lint.sh` for GitHub markdown posting safety.
+
+## Canon Workflow Rules
+
+1. Issue-first for non-trivial work. Exception: spikes (`.planning/` doc-only investigations) only need a branch — no GitHub issue required.
+2. Branch-per-issue (or branch-per-spike for spikes).
+3. Keep PR scope to one logical slice.
+4. Update planning briefs the same day issue state changes.
+5. Preserve AC -> Test traceability in story files.
+6. Sync GitHub issue lifecycle continuously, not just at closeout:
+   - Set issue to `in-progress` when implementation starts.
+   - Comment with commit SHAs and test evidence as slices land.
+
+thinking
+**Preparing to run targeted searches**
+exec
+rg -n 'getTitle|title.*json|json.*title' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 23ms:
+3548:        const char *title = w->getTitle(0);
+3549:        std::string safeTitle = title ? jsonEscape(title) : std::string("");
+3550:        json += "      \"title\": \"" + safeTitle + "\",\n";
+
+thinking
+**Preparing to extract surrounding context**
+
+I'm planning to use sed to capture surrounding lines for better context in the current exploration.
+exec
+sed -n '3515,3585p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 17ms:
+                } else if (dynamic_cast<TRadialGradientView*>(c)) {
+                    props = "{\"gradientType\": \"radial\"}"; break;
+                } else if (dynamic_cast<TDiagonalGradientView*>(c)) {
+                    props = "{\"gradientType\": \"diagonal\"}"; break;
+                }
+                c = c->next;
+            } while (c != cStart);
+            }
+        } else if (type == "gallery") {
+            if (auto *gallery = dynamic_cast<TGalleryWindow*>(w)) {
+                props = std::string("{\"tab\": ") + std::to_string(gallery->getSelected());
+                const std::string& searchText = gallery->getSearchText();
+                props += std::string(", \"search\": \"") + jsonEscape(searchText) + "\"}";
+            }
+        }
+
+        // Bounds (outer window rect)
+        TRect b = w->getBounds();
+        int x = b.a.x, y = b.a.y, ww = b.b.x - b.a.x, hh = b.b.y - b.a.y;
+
+
+thinking
+**Locating frame_player block for title update**
+exec
+rg -n frame_player app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 40ms:
+3281:        } else if (type == "frame_player") {
+3498:        } else if (type == "frame_player") {
+exec
+sed -n '3260,3325p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 15ms:
+        if (x < 0) x = 0; if (y < 0) y = 0;
+        if (x + w > maxW) x = std::max(0, maxW - w);
+        if (y + h > maxH) y = std::max(0, maxH - h);
+        TRect bounds(x,y,x+w,y+h);
+
+        TWindow *win = nullptr;
+        if (type == "test_pattern") {
+            win = new TTestPatternWindow(bounds, "");
+        } else if (type == "gradient") {
+            std::string gtype; // props.gradientType preferred
+            size_t propsPos = obj.find("\"props\"");
+            if (propsPos != std::string::npos) {
+                size_t brace = obj.find('{', propsPos);
+                if (brace != std::string::npos)
+                    parseKeyedString(obj, brace+1, "gradientType", gtype);
+            }
+            TGradientWindow::GradientType gt = TGradientWindow::gtHorizontal;
+            if (gtype == "vertical") gt = TGradientWindow::gtVertical;
+            else if (gtype == "radial") gt = TGradientWindow::gtRadial;
+            else if (gtype == "diagonal") gt = TGradientWindow::gtDiagonal;
+
+thinking
+**Planning title serialization update**
+
+I need to modify title serialization in buildWorkspaceJson to use getFilePath and stem. Next, I'll locate the TFrameAnimationWindow class and consider adding a helper, starting by searching for getFilePath.
+exec
+rg -n getFilePath app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 18ms:
+669:    const std::string& getFilePath() const { return filePath_; }
+2891:            const std::string& p = ttw->getFilePath();
+2894:            const std::string& p = faw->getFilePath();
+3501:                const std::string& fp = faw->getFilePath();
+exec
+sed -n '2865,2925p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 17ms:
+
+    std::stringstream json;
+    json << "{\"windows\":[";
+
+    bool first = true;
+    for (TWindow* w : activeWins) {
+        std::string id = app.registerWindow(w, false);
+        if (!first) json << ",";
+        json << "{\"id\":\"" << id << "\""
+             << ",\"type\":\"" << windowTypeName(w) << "\""
+             << ",\"x\":" << w->origin.x
+             << ",\"y\":" << w->origin.y
+             << ",\"w\":" << w->size.x
+             << ",\"h\":" << w->size.y
+             << ",\"title\":\"";
+        if (w->title) {
+            std::string title(w->title);
+            for (char c : title) {
+                if (c == '"') json << "\\\"";
+                else if (c == '\\') json << "\\\\";
+
+thinking
+**Checking frame_player block**
+
+I'm verifying the frame_player block around line 3498 in buildWorkspaceJson to confirm if it handles title writing, aiming to update it to use the file path stem and apply JSON escaping when the title is empty.
+exec
+sed -n '3460,3525p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 16ms:
+    // Screen size
+    TRect ext = deskTop->getExtent();
+    int sw = ext.b.x - ext.a.x;
+    int sh = ext.b.y - ext.a.y;
+
+    // Timestamp (basic)
+    char ts[64];
+    std::time_t t = std::time(nullptr);
+    std::tm *lt = std::localtime(&t);
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", lt);
+
+    std::string json;
+    json += "{\n";
+    json += "  \"version\": 1,\n";
+    json += "  \"app\": \"test_pattern\",\n";
+    json += std::string("  \"timestamp\": \"") + ts + "\",\n";
+    json += "  \"screen\": { \"width\": " + std::to_string(sw) + ", \"height\": " + std::to_string(sh) + " },\n";
+    json += std::string("  \"globals\": { \"patternMode\": \"") + (USE_CONTINUOUS_PATTERN ? "continuous" : "tiled") + "\" },\n";
+    json += "  \"windows\": [\n";
+
+
+thinking
+**Planning title derivation on restore**
+
+I'm investigating using the file path to derive the title if it's missing and considering introducing a helper for the frame_player to parse the top-level title during workspace restoration, focusing around loadWorkspaceFromFile to leverage existing title handling.
+exec
+rg -n "parseKeyedString\\(obj, .*\"title\"" app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 22ms:
+3250:        std::string title; parseKeyedString(obj, 0, "title", title);
+exec
+sed -n '3225,3275p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 17ms:
+        ++p;
+    }
+
+    // Close current windows
+    closeAll();
+
+    // Apply globals
+    USE_CONTINUOUS_PATTERN = continuous;
+
+    // Restore windows
+    std::vector<TWindow*> created;
+    auto captureWindows = [this]() {
+        std::vector<TWindow*> out;
+        TView *start = deskTop->first();
+        if (!start) return out;
+        TView *v = start;
+        do {
+            if (TWindow *w = dynamic_cast<TWindow*>(v))
+                out.push_back(w);
+            v = v->next;
+
+
+thinking
+**Planning title fallback logic**
+
+I'm outlining a fallback for empty titles in frame_player type by extracting the file path stem, ensuring JSON-safe output with jsonEscape, and avoiding property changes by only applying it during title writing.
+thinking
+**Implementing and applying title fallback patch**
+
+I'm coding the fallback logic that extracts and cleans the filename stem for frame_player titles when missing, ensuring safe JSON output, then integrating it into the openAnimationFilePath call only if the path exists. Next, I'll build the project to verify changes.
+file update
+M /Users/james/Repos/wibandwob-dos/app/test_pattern_app.cpp
+@@ -3548,3 +3548,20 @@
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+apply_patch(auto_approved=true) exited 0 in 49ms:
+Success. Updated the following files:
+M app/test_pattern_app.cpp
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..41799bc9e2d264130a6675c4c8c7e9e3833fdb3a
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..41799bc9e2d264130a6675c4c8c7e9e3833fdb3a
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+
+thinking
+**Updating restore call for patch**
+file update
+M /Users/james/Repos/wibandwob-dos/app/test_pattern_app.cpp
+@@ -3292,3 +3292,3 @@
+             }
+-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
++            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+             continue; // openAnimationFilePath handles insert + register
+apply_patch(auto_approved=true) exited 0 in 47ms:
+Success. Updated the following files:
+M app/test_pattern_app.cpp
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..210fd22093f321e826f4f4906546c2696cc04743
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3290,7 +3290,7 @@
+                     if (!pmsStr.empty()) pms = (unsigned)std::stoul(pmsStr);
+                 }
+             }
+-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
++            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+             continue; // openAnimationFilePath handles insert + register
+         } else if (type == "text_view") {
+             std::string path;
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..210fd22093f321e826f4f4906546c2696cc04743
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3290,7 +3290,7 @@
+                     if (!pmsStr.empty()) pms = (unsigned)std::stoul(pmsStr);
+                 }
+             }
+-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
++            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+             continue; // openAnimationFilePath handles insert + register
+         } else if (type == "text_view") {
+             std::string path;
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+
+thinking
+**Preparing to add build command**
+exec
+/bin/sh -c 'cmake --build ./build --target test_pattern -j4 2>&1 | grep -E "error:|Linking"' in /Users/james/Repos/wibandwob-dos succeeded in 11.64s:
+[ 84%] Linking CXX executable test_pattern
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..210fd22093f321e826f4f4906546c2696cc04743
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3290,7 +3290,7 @@
+                     if (!pmsStr.empty()) pms = (unsigned)std::stoul(pmsStr);
+                 }
+             }
+-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
++            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+             continue; // openAnimationFilePath handles insert + register
+         } else if (type == "text_view") {
+             std::string path;
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+
+thinking
+**Planning for line-numbered summaries**
+
+I'm deciding to use rg -n to find lines with titleValue for accurate line-numbered change summaries and to compute precise line numbers for the final test and code additions.
+exec
+rg -n "titleValue|openAnimationFilePath\\(path, bounds, false, false, title\\)" app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 37ms:
+3293:            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+3549:        std::string titleValue;
+3551:            titleValue = title;
+3562:                    titleValue = base;
+3566:        std::string safeTitle = jsonEscape(titleValue);
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..210fd22093f321e826f4f4906546c2696cc04743
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3290,7 +3290,7 @@
+                     if (!pmsStr.empty()) pms = (unsigned)std::stoul(pmsStr);
+                 }
+             }
+-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
++            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+             continue; // openAnimationFilePath handles insert + register
+         } else if (type == "text_view") {
+             std::string path;
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+codex
+**Summary**
+- Add frame_player title fallback to file stem when empty, then JSON-escape before save in `app/test_pattern_app.cpp:3549`.
+- Pass workspace `title` into `openAnimationFilePath` for frame_player restore in `app/test_pattern_app.cpp:3293`.
+
+**Tests**
+- `cmake --build ./build --target test_pattern -j4 2>&1 | grep -E "error:|Linking"`
+
+Want me to run any additional tests or handle the issue/PR lifecycle updates for #84?
+file update:
+diff --git a/app/test_pattern_app.cpp b/app/test_pattern_app.cpp
+index 5fc673172ded561bb9fc69375d023c62c98399a8..210fd22093f321e826f4f4906546c2696cc04743
+--- a/app/test_pattern_app.cpp
++++ b/app/test_pattern_app.cpp
+@@ -3290,7 +3290,7 @@
+                     if (!pmsStr.empty()) pms = (unsigned)std::stoul(pmsStr);
+                 }
+             }
+-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
++            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
+             continue; // openAnimationFilePath handles insert + register
+         } else if (type == "text_view") {
+             std::string path;
+@@ -3546,7 +3546,24 @@
+         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
+         json += "      \"type\": \"" + type + "\",\n";
+         const char *title = w->getTitle(0);
+-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
++        std::string titleValue;
++        if (title && *title) {
++            titleValue = title;
++        } else if (type == "frame_player") {
++            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
++                const std::string& fp = faw->getFilePath();
++                if (!fp.empty()) {
++                    size_t slash = fp.find_last_of("/\\");
++                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
++                    std::string base = fp.substr(start);
++                    size_t dot = base.find_last_of('.');
++                    if (dot != std::string::npos && dot != 0)
++                        base = base.substr(0, dot);
++                    titleValue = base;
++                }
++            }
++        }
++        std::string safeTitle = jsonEscape(titleValue);
+         json += "      \"title\": \"" + safeTitle + "\",\n";
+         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
+         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";
+
+tokens used
+30,885
+**Summary**
+- Add frame_player title fallback to file stem when empty, then JSON-escape before save in `app/test_pattern_app.cpp:3549`.
+- Pass workspace `title` into `openAnimationFilePath` for frame_player restore in `app/test_pattern_app.cpp:3293`.
+
+**Tests**
+- `cmake --build ./build --target test_pattern -j4 2>&1 | grep -E "error:|Linking"`
+
+Want me to run any additional tests or handle the issue/PR lifecycle updates for #84?

--- a/.codex-logs/2026-02-23/f06-parity-160911.log
+++ b/.codex-logs/2026-02-23/f06-parity-160911.log
@@ -1,0 +1,1314 @@
+OpenAI Codex v0.53.0 (research preview)
+--------
+workdir: /Users/james/Repos/wibandwob-dos
+model: gpt-5.2-codex
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: auto
+session id: 019c8b43-1078-7492-a3d1-0bec9c55b371
+--------
+user
+DEVNOTE: Files inside .codex-logs/ are run logs — ignore them completely.
+EFFICIENCY: Use rg -n -C3 or sed -n 'N,Mp'. Never dump full files.
+
+Task: write scripts/parity-check.py — a surface parity audit script (issue #86, AC-15).
+
+The script reads C++ source to find gaps between:
+  A) Types registered in window_type_registry (k_specs[] array) 
+  B) Types with props serialisation in buildWorkspaceJson
+  C) Types with restore handling in loadWorkspaceFromFile
+
+Script should:
+1. Parse app/window_type_registry.cpp — extract all type slugs from k_specs[] lines
+   Pattern: lines like: { "gallery", spawn_gallery, match_gallery },
+   
+2. Parse app/test_pattern_app.cpp — find buildWorkspaceJson section
+   Extract all type == "X" strings within it (these have props save)
+   
+3. Parse app/test_pattern_app.cpp — find loadWorkspaceFromFile section  
+   Extract all type == "X" strings within it (these have restore handling)
+
+4. Define STATELESS_TYPES = set of types that are intentionally stateless (no props needed):
+   terminal, browser, scramble, quadra, snake, rogue, deep_signal, app_launcher,
+   wibwob, orbit, torus, cube, life, blocks, score, ascii, animated_gradient,
+   monster_cam, monster_verse, monster_portal, paint, micropolis_ascii,
+   mycelium, verse, text_editor, test_pattern, gradient
+
+5. Print a table: TYPE | REGISTRY | PROPS_SAVE | RESTORE | STATUS
+   Mark each type: ✅ ok / ⚠️ gap / — stateless
+
+6. Exit non-zero if any registered type is NOT in stateless list AND missing props save or restore.
+   Exit 0 if all types are either covered or explicitly stateless.
+
+Output format:
+  TYPE                 REGISTRY   SAVE       RESTORE    STATUS
+  frame_player         ✅          ✅          ✅          ok
+  gallery              ✅          ✅          ✅          ok
+  terminal             ✅          —           —           stateless
+  <hypothetical_new>   ✅          ❌          ❌          GAP ← exits non-zero
+
+Put the script at scripts/parity-check.py.
+Make it executable (chmod +x).
+Test it: python3 scripts/parity-check.py — should exit 0 on current clean repo.
+Print the full table to stdout regardless of exit code.
+exec
+ls in /Users/james/Repos/wibandwob-dos succeeded in 19ms:
+260221-1612-w4-no-input-no-change-no-spawned.txt
+260221-1612-w5-maximum-entropy-achieved-all-gradient-spawned.txt
+260221-1612-w6-every-word-is-a-translation-spawned.txt
+260221-1614-win-9e40476d--BAT-TECHNO-SEARCH-spawned.txt
+260221-1822-w3-Hello-from-smoke-test-spawned.txt
+260222-1953-w3--o-o-spawned.txt
+AGENTS.md
+CLAUDE.md
+CMakeLists.txt
+README.md
+app
+archive
+build
+cache
+codex-wibwob-mcp-fix-20260221-125722.log
+contracts
+docs
+logs
+memories
+modules
+
+thinking
+**Identifying root agents**
+exec
+cat AGENTS.md in /Users/james/Repos/wibandwob-dos succeeded in 16ms:
+# AGENTS.md (Codex Prompt-Shim)
+
+This file aligns Codex execution style with the repo canon in `.planning/README.md` and the guardrails encoded in `.claude/hooks/*`.
+
+## Important: Hooks vs Codex
+
+Codex does not natively execute Claude Code hook scripts.  
+Treat the rules below as a required prompt-shim and manual gate before finishing work.
+Mirror high-value hook behavior explicitly, including `.claude/hooks/gh-format-lint.sh` for GitHub markdown posting safety.
+
+## Canon Workflow Rules
+
+1. Issue-first for non-trivial work. Exception: spikes (`.planning/` doc-only investigations) only need a branch — no GitHub issue required.
+2. Branch-per-issue (or branch-per-spike for spikes).
+3. Keep PR scope to one logical slice.
+4. Update planning briefs the same day issue state changes.
+5. Preserve AC -> Test traceability in story files.
+6. Sync GitHub issue lifecycle continuously, not just at closeout:
+   - Set issue to `in-progress` when implementation starts.
+   - Comment with commit SHAs and test evidence as slices land.
+
+thinking
+**Planning to find all agent references**
+
+I'll search through the scripts for all occurrences of "AGENTS" to ensure no references are missed.
+exec
+rg --files -g AGENTS.md in /Users/james/Repos/wibandwob-dos succeeded in 41ms:
+AGENTS.md
+
+thinking
+**Preparing to parse source sections**
+
+I'm planning to use sed to inspect and parse relevant sections of the small app/window_type_registry.cpp file as part of script creation based on the instructions.
+exec
+sed -n '1,200p' app/window_type_registry.cpp in /Users/james/Repos/wibandwob-dos succeeded in 17ms:
+// Window type registry — single source of truth for all spawnable window types.
+// Keeps api_ipc.cpp free of per-type knowledge: adding a new type only requires
+// a new entry in the k_specs table below.
+
+#include "window_type_registry.h"
+#include "gradient.h"
+#include "frame_file_player_view.h"
+#include "transparent_text_view.h"
+#include "text_editor_view.h"
+#include "browser_view.h"
+#include "generative_verse_view.h"
+#include "generative_mycelium_view.h"
+#include "generative_orbit_view.h"
+#include "generative_torus_view.h"
+#include "generative_cube_view.h"
+#include "game_of_life_view.h"
+#include "animated_blocks_view.h"
+#include "animated_score_view.h"
+#include "animated_ascii_view.h"
+#include "animated_gradient_view.h"
+
+thinking
+**Planning to locate k_specs array**
+exec
+rg -n -C3 k_specs app/window_type_registry.cpp in /Users/james/Repos/wibandwob-dos succeeded in 19ms:
+1-// Window type registry — single source of truth for all spawnable window types.
+2-// Keeps api_ipc.cpp free of per-type knowledge: adding a new type only requires
+3:// a new entry in the k_specs table below.
+4-
+5-#include "window_type_registry.h"
+6-#include "gradient.h"
+--
+277-// ── Registry table ────────────────────────────────────────────────────────────
+278-// Add new window types here — nowhere else.
+279-
+280:static const WindowTypeSpec k_specs[] = {
+281-    { "test_pattern",      spawn_test,              match_test_pattern      },
+282-    { "gradient",          spawn_gradient,          match_gradient          },
+283-    { "frame_player",      spawn_frame_player,      match_frame_player      },
+--
+317-
+318-const std::vector<WindowTypeSpec>& all_window_type_specs() {
+319-    static std::vector<WindowTypeSpec> specs(
+320:        k_specs, k_specs + sizeof(k_specs) / sizeof(k_specs[0]));
+321-    return specs;
+exec
+sed -n '270,340p' app/window_type_registry.cpp in /Users/james/Repos/wibandwob-dos succeeded in 16ms:
+static bool match_quadra(TWindow* w)      { return has_child_view<TQuadraView>(w); }
+static bool match_snake(TWindow* w)       { return has_child_view<TSnakeView>(w); }
+static bool match_rogue(TWindow* w)       { return has_child_view<TRogueView>(w); }
+static bool match_deep_signal(TWindow* w) { return has_child_view<TDeepSignalView>(w); }
+static bool match_app_launcher(TWindow* w){ return dynamic_cast<TAppLauncherWindow*>(w) != nullptr; }
+static bool match_gallery(TWindow* w)     { return dynamic_cast<TGalleryWindow*>(w) != nullptr; }
+
+// ── Registry table ────────────────────────────────────────────────────────────
+// Add new window types here — nowhere else.
+
+static const WindowTypeSpec k_specs[] = {
+    { "test_pattern",      spawn_test,              match_test_pattern      },
+    { "gradient",          spawn_gradient,          match_gradient          },
+    { "frame_player",      spawn_frame_player,      match_frame_player      },
+    { "text_view",         spawn_text_view,         match_text_view         },
+    { "text_editor",       spawn_text_editor,       match_text_editor       },
+    { "browser",           spawn_browser,           match_browser           },
+    { "verse",             spawn_verse,             match_verse             },
+    { "mycelium",          spawn_mycelium,          match_mycelium          },
+    { "orbit",             spawn_orbit,             match_orbit             },
+
+thinking
+**Locating workspace JSON functions**
+
+I'm searching for buildWorkspaceJson and loadWorkspaceFromFile in test_pattern_app.cpp to understand workspace parsing.
+exec
+rg -n -C3 buildWorkspaceJson app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 19ms:
+723-    void saveWorkspace();
+724-    bool saveWorkspacePath(const std::string& path);
+725-    TRect calculateWindowBounds(const std::string& filePath);
+726:    std::string buildWorkspaceJson();
+727-    static std::string jsonEscape(const std::string& s);
+728-    bool loadWorkspaceFromFile(const std::string& path);
+729-    static bool parseBool(const std::string &s, size_t &pos, bool &out);
+--
+3455-    return out;
+3456-}
+3457-
+3458:std::string TTestPatternApp::buildWorkspaceJson()
+3459-{
+3460-    // Screen size
+3461-    TRect ext = deskTop->getExtent();
+--
+3568-    // Ensure directory exists
+3569-    mkdir("workspaces", 0755);
+3570-
+3571:    std::string json = buildWorkspaceJson();
+exec
+sed -n '3450,3590p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 16ms:
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    out += buf;
+                } else out += char(c);
+        }
+    }
+    return out;
+}
+
+std::string TTestPatternApp::buildWorkspaceJson()
+{
+    // Screen size
+    TRect ext = deskTop->getExtent();
+    int sw = ext.b.x - ext.a.x;
+    int sh = ext.b.y - ext.a.y;
+
+    // Timestamp (basic)
+    char ts[64];
+    std::time_t t = std::time(nullptr);
+    std::tm *lt = std::localtime(&t);
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", lt);
+
+thinking
+**Planning to locate loadWorkspaceFromFile**
+exec
+rg -n -C3 loadWorkspaceFromFile app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 19ms:
+725-    TRect calculateWindowBounds(const std::string& filePath);
+726-    std::string buildWorkspaceJson();
+727-    static std::string jsonEscape(const std::string& s);
+728:    bool loadWorkspaceFromFile(const std::string& path);
+729-    static bool parseBool(const std::string &s, size_t &pos, bool &out);
+730-    static bool parseString(const std::string &s, size_t &pos, std::string &out);
+731-    static bool parseNumber(const std::string &s, size_t &pos, int &out);
+--
+950-    const char* layoutPath = std::getenv("WIBWOB_LAYOUT_PATH");
+951-    if (layoutPath && layoutPath[0] != '\0') {
+952-        fprintf(stderr, "[wibwob] Restoring layout from WIBWOB_LAYOUT_PATH=%s\n", layoutPath);
+953:        if (!loadWorkspaceFromFile(layoutPath)) {
+954-            fprintf(stderr, "[wibwob] WARNING: Failed to restore layout from %s\n", layoutPath);
+955-        }
+956-    }
+--
+3169-    return false;
+3170-}
+3171-
+3172:bool TTestPatternApp::loadWorkspaceFromFile(const std::string& path)
+exec
+sed -n '3170,3425p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 16ms:
+}
+
+bool TTestPatternApp::loadWorkspaceFromFile(const std::string& path)
+{
+    std::ifstream in(path);
+    if (!in) {
+        std::string msg = std::string("Failed to open ") + path;
+        messageBox(msg.c_str(), mfError | mfOKButton);
+        return false;
+    }
+    std::string data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+
+    if (data.find("\"version\"") == std::string::npos || data.find("\"windows\"") == std::string::npos) {
+        messageBox("Invalid workspace file.", mfError | mfOKButton);
+        return false;
+    }
+
+    // Extract globals.patternMode
+    bool continuous = USE_CONTINUOUS_PATTERN;
+
+
+thinking
+**Planning targeted parsing script**
+
+I'm outlining a Python script to extract specific code sections by locating function or array boundaries via string searches, then applying regex inside those regions to find patterns like `type == "X"` and entries within the `k_specs` array, ensuring scoped parsing within identified code blocks.
+thinking
+**Searching for function boundary**
+
+I'm locating the `loadWorkspace` function start, around line 3390, to define parsing boundaries by finding its occurrence using a code search for precise extraction range.
+exec
+rg -n -C1 TTestPatternApp::loadWorkspace app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 19ms:
+3171-
+3172:bool TTestPatternApp::loadWorkspaceFromFile(const std::string& path)
+3173-{
+
+thinking
+**Considering function name patterns**
+
+Noticing "loadWorkspace" might be a key function name to target with text replacements using sed near the final steps.
+exec
+sed -n '3400,3505p' app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 17ms:
+    std::strncpy(fileName, "workspaces/*.json", sizeof(fileName));
+    fileName[sizeof(fileName)-1] = '\0';
+    TFileDialog *dlg = new TFileDialog("workspaces/*.json", "Open Workspace", "~N~ame", fdOpenButton, 101);
+    ushort res = deskTop->execView(dlg);
+    std::string path;
+    if (res != cmCancel) {
+        dlg->getData(fileName);
+        path = fileName;
+        // Normalize: if only a filename, prepend workspaces/
+        if (!path.empty() && path.find('/') == std::string::npos)
+            path = std::string("workspaces/") + path;
+    } else {
+        path = "workspaces/last_workspace.json";
+    }
+    destroy(dlg);
+
+    // Fallback if file missing: try default
+    std::ifstream test(path.c_str());
+    if (!test.good()) {
+        test.close();
+
+
+thinking
+**Planning parsing and output logic**
+
+I'm defining how to isolate the restore section by slicing between `loadWorkspaceFromFile` start and `loadWorkspace` start using regex. The output should be a sorted table listing all registry types with statuses reflecting presence in save (build), restore (load), or stateless sets, marking gaps and stateless types accordingly.
+thinking
+**Deciding on union vs registry-only listing**
+
+I clarified output should show all types from the union of registry, save, and restore sets to surface mismatches, marking registry presence explicitly. However, exit criteria only matter for registered types missing save or restore. I sketched a detailed script plan to parse registry and function sections, extract types, mark statuses per instructions, format a neat table, and handle stateless types distinctly. Next step is implementing this script as an executable file.
+file update
+A /Users/james/Repos/wibandwob-dos/scripts/parity-check.py
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+STATELESS_TYPES = {
+    "terminal",
+    "browser",
+    "scramble",
+    "quadra",
+    "snake",
+    "rogue",
+    "deep_signal",
+    "app_launcher",
+    "wibwob",
+    "orbit",
+    "torus",
+    "cube",
+    "life",
+    "blocks",
+    "score",
+    "ascii",
+    "animated_gradient",
+    "monster_cam",
+    "monster_verse",
+    "monster_portal",
+    "paint",
+    "micropolis_ascii",
+    "mycelium",
+    "verse",
+    "text_editor",
+    "test_pattern",
+    "gradient",
+}
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"Missing file: {path}", file=sys.stderr)
+        raise
+
+
+def extract_registry_types(text: str) -> list[str]:
+    start = text.find("k_specs[]")
+    if start == -1:
+        return []
+    brace_start = text.find("{", start)
+    if brace_start == -1:
+        return []
+    end = text.find("};", brace_start)
+    if end == -1:
+        end = len(text)
+    block = text[brace_start:end]
+    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
+    return pattern.findall(block)
+
+
+def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
+    start = text.find(start_token)
+    if start == -1:
+        return ""
+    end = len(text)
+    for token in end_tokens:
+        idx = text.find(token, start + len(start_token))
+        if idx != -1:
+            end = min(end, idx)
+    return text[start:end]
+
+
+def extract_type_conditions(section: str) -> set[str]:
+    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    registry_path = root / "app" / "window_type_registry.cpp"
+    app_path = root / "app" / "test_pattern_app.cpp"
+
+    registry_text = read_text(registry_path)
+    app_text = read_text(app_path)
+
+    registry_types = extract_registry_types(registry_text)
+
+    build_section = extract_section(
+        app_text,
+        "std::string TTestPatternApp::buildWorkspaceJson",
+        ["void TTestPatternApp::saveWorkspace"],
+    )
+    restore_section = extract_section(
+        app_text,
+        "bool TTestPatternApp::loadWorkspaceFromFile",
+        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
+    )
+
+    save_types = extract_type_conditions(build_section)
+    restore_types = extract_type_conditions(restore_section)
+
+    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
+    reg_width = len("REGISTRY")
+    save_width = len("SAVE")
+    restore_width = len("RESTORE")
+
+    header = (
+        f"{'TYPE':<{type_width}}  "
+        f"{'REGISTRY':<{reg_width}}  "
+        f"{'SAVE':<{save_width}}  "
+        f"{'RESTORE':<{restore_width}}  "
+        "STATUS"
+    )
+    print(header)
+
+    has_gap = False
+    for type_name in registry_types:
+        reg_cell = "✅"
+        if type_name in STATELESS_TYPES:
+            save_cell = "—"
+            restore_cell = "—"
+            status = "stateless"
+        else:
+            save_ok = type_name in save_types
+            restore_ok = type_name in restore_types
+            save_cell = "✅" if save_ok else "❌"
+            restore_cell = "✅" if restore_ok else "❌"
+            status = "ok" if save_ok and restore_ok else "GAP"
+            if status == "GAP":
+                has_gap = True
+
+        print(
+            f"{type_name:<{type_width}}  "
+            f"{reg_cell:<{reg_width}}  "
+            f"{save_cell:<{save_width}}  "
+            f"{restore_cell:<{restore_width}}  "
+            f"{status}"
+        )
+
+    return 1 if has_gap else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+apply_patch(auto_approved=true) exited 0 in 46ms:
+Success. Updated the following files:
+A scripts/parity-check.py
+file update:
+diff --git a/scripts/parity-check.py b/scripts/parity-check.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..77a717805c20a1ec4837f931274706cf49bf661f
+--- /dev/null
++++ b/scripts/parity-check.py
+@@ -0,0 +1,146 @@
++#!/usr/bin/env python3
++
++from __future__ import annotations
++
++import re
++import sys
++from pathlib import Path
++
++
++STATELESS_TYPES = {
++    "terminal",
++    "browser",
++    "scramble",
++    "quadra",
++    "snake",
++    "rogue",
++    "deep_signal",
++    "app_launcher",
++    "wibwob",
++    "orbit",
++    "torus",
++    "cube",
++    "life",
++    "blocks",
++    "score",
++    "ascii",
++    "animated_gradient",
++    "monster_cam",
++    "monster_verse",
++    "monster_portal",
++    "paint",
++    "micropolis_ascii",
++    "mycelium",
++    "verse",
++    "text_editor",
++    "test_pattern",
++    "gradient",
++}
++
++
++def read_text(path: Path) -> str:
++    try:
++        return path.read_text(encoding="utf-8")
++    except FileNotFoundError:
++        print(f"Missing file: {path}", file=sys.stderr)
++        raise
++
++
++def extract_registry_types(text: str) -> list[str]:
++    start = text.find("k_specs[]")
++    if start == -1:
++        return []
++    brace_start = text.find("{", start)
++    if brace_start == -1:
++        return []
++    end = text.find("};", brace_start)
++    if end == -1:
++        end = len(text)
++    block = text[brace_start:end]
++    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
++    return pattern.findall(block)
++
++
++def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
++    start = text.find(start_token)
++    if start == -1:
++        return ""
++    end = len(text)
++    for token in end_tokens:
++        idx = text.find(token, start + len(start_token))
++        if idx != -1:
++            end = min(end, idx)
++    return text[start:end]
++
++
++def extract_type_conditions(section: str) -> set[str]:
++    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
++
++
++def main() -> int:
++    root = Path(__file__).resolve().parents[1]
++    registry_path = root / "app" / "window_type_registry.cpp"
++    app_path = root / "app" / "test_pattern_app.cpp"
++
++    registry_text = read_text(registry_path)
++    app_text = read_text(app_path)
++
++    registry_types = extract_registry_types(registry_text)
++
++    build_section = extract_section(
++        app_text,
++        "std::string TTestPatternApp::buildWorkspaceJson",
++        ["void TTestPatternApp::saveWorkspace"],
++    )
++    restore_section = extract_section(
++        app_text,
++        "bool TTestPatternApp::loadWorkspaceFromFile",
++        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
++    )
++
++    save_types = extract_type_conditions(build_section)
++    restore_types = extract_type_conditions(restore_section)
++
++    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
++    reg_width = len("REGISTRY")
++    save_width = len("SAVE")
++    restore_width = len("RESTORE")
++
++    header = (
++        f"{'TYPE':<{type_width}}  "
++        f"{'REGISTRY':<{reg_width}}  "
++        f"{'SAVE':<{save_width}}  "
++        f"{'RESTORE':<{restore_width}}  "
++        "STATUS"
++    )
++    print(header)
++
++    has_gap = False
++    for type_name in registry_types:
++        reg_cell = "✅"
++        if type_name in STATELESS_TYPES:
++            save_cell = "—"
++            restore_cell = "—"
++            status = "stateless"
++        else:
++            save_ok = type_name in save_types
++            restore_ok = type_name in restore_types
++            save_cell = "✅" if save_ok else "❌"
++            restore_cell = "✅" if restore_ok else "❌"
++            status = "ok" if save_ok and restore_ok else "GAP"
++            if status == "GAP":
++                has_gap = True
++
++        print(
++            f"{type_name:<{type_width}}  "
++            f"{reg_cell:<{reg_width}}  "
++            f"{save_cell:<{save_width}}  "
++            f"{restore_cell:<{restore_width}}  "
++            f"{status}"
++        )
++
++    return 1 if has_gap else 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+
+file update:
+diff --git a/scripts/parity-check.py b/scripts/parity-check.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..77a717805c20a1ec4837f931274706cf49bf661f
+--- /dev/null
++++ b/scripts/parity-check.py
+@@ -0,0 +1,146 @@
++#!/usr/bin/env python3
++
++from __future__ import annotations
++
++import re
++import sys
++from pathlib import Path
++
++
++STATELESS_TYPES = {
++    "terminal",
++    "browser",
++    "scramble",
++    "quadra",
++    "snake",
++    "rogue",
++    "deep_signal",
++    "app_launcher",
++    "wibwob",
++    "orbit",
++    "torus",
++    "cube",
++    "life",
++    "blocks",
++    "score",
++    "ascii",
++    "animated_gradient",
++    "monster_cam",
++    "monster_verse",
++    "monster_portal",
++    "paint",
++    "micropolis_ascii",
++    "mycelium",
++    "verse",
++    "text_editor",
++    "test_pattern",
++    "gradient",
++}
++
++
++def read_text(path: Path) -> str:
++    try:
++        return path.read_text(encoding="utf-8")
++    except FileNotFoundError:
++        print(f"Missing file: {path}", file=sys.stderr)
++        raise
++
++
++def extract_registry_types(text: str) -> list[str]:
++    start = text.find("k_specs[]")
++    if start == -1:
++        return []
++    brace_start = text.find("{", start)
++    if brace_start == -1:
++        return []
++    end = text.find("};", brace_start)
++    if end == -1:
++        end = len(text)
++    block = text[brace_start:end]
++    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
++    return pattern.findall(block)
++
++
++def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
++    start = text.find(start_token)
++    if start == -1:
++        return ""
++    end = len(text)
++    for token in end_tokens:
++        idx = text.find(token, start + len(start_token))
++        if idx != -1:
++            end = min(end, idx)
++    return text[start:end]
++
++
++def extract_type_conditions(section: str) -> set[str]:
++    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
++
++
++def main() -> int:
++    root = Path(__file__).resolve().parents[1]
++    registry_path = root / "app" / "window_type_registry.cpp"
++    app_path = root / "app" / "test_pattern_app.cpp"
++
++    registry_text = read_text(registry_path)
++    app_text = read_text(app_path)
++
++    registry_types = extract_registry_types(registry_text)
++
++    build_section = extract_section(
++        app_text,
++        "std::string TTestPatternApp::buildWorkspaceJson",
++        ["void TTestPatternApp::saveWorkspace"],
++    )
++    restore_section = extract_section(
++        app_text,
++        "bool TTestPatternApp::loadWorkspaceFromFile",
++        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
++    )
++
++    save_types = extract_type_conditions(build_section)
++    restore_types = extract_type_conditions(restore_section)
++
++    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
++    reg_width = len("REGISTRY")
++    save_width = len("SAVE")
++    restore_width = len("RESTORE")
++
++    header = (
++        f"{'TYPE':<{type_width}}  "
++        f"{'REGISTRY':<{reg_width}}  "
++        f"{'SAVE':<{save_width}}  "
++        f"{'RESTORE':<{restore_width}}  "
++        "STATUS"
++    )
++    print(header)
++
++    has_gap = False
++    for type_name in registry_types:
++        reg_cell = "✅"
++        if type_name in STATELESS_TYPES:
++            save_cell = "—"
++            restore_cell = "—"
++            status = "stateless"
++        else:
++            save_ok = type_name in save_types
++            restore_ok = type_name in restore_types
++            save_cell = "✅" if save_ok else "❌"
++            restore_cell = "✅" if restore_ok else "❌"
++            status = "ok" if save_ok and restore_ok else "GAP"
++            if status == "GAP":
++                has_gap = True
++
++        print(
++            f"{type_name:<{type_width}}  "
++            f"{reg_cell:<{reg_width}}  "
++            f"{save_cell:<{save_width}}  "
++            f"{restore_cell:<{restore_width}}  "
++            f"{status}"
++        )
++
++    return 1 if has_gap else 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+
+
+thinking
+**Adding executable permission**
+exec
+chmod +x scripts/parity-check.py in /Users/james/Repos/wibandwob-dos succeeded in 29ms:
+
+file update:
+diff --git a/scripts/parity-check.py b/scripts/parity-check.py
+new file mode 100755
+index 0000000000000000000000000000000000000000..77a717805c20a1ec4837f931274706cf49bf661f
+--- /dev/null
++++ b/scripts/parity-check.py
+@@ -0,0 +1,146 @@
++#!/usr/bin/env python3
++
++from __future__ import annotations
++
++import re
++import sys
++from pathlib import Path
++
++
++STATELESS_TYPES = {
++    "terminal",
++    "browser",
++    "scramble",
++    "quadra",
++    "snake",
++    "rogue",
++    "deep_signal",
++    "app_launcher",
++    "wibwob",
++    "orbit",
++    "torus",
++    "cube",
++    "life",
++    "blocks",
++    "score",
++    "ascii",
++    "animated_gradient",
++    "monster_cam",
++    "monster_verse",
++    "monster_portal",
++    "paint",
++    "micropolis_ascii",
++    "mycelium",
++    "verse",
++    "text_editor",
++    "test_pattern",
++    "gradient",
++}
++
++
++def read_text(path: Path) -> str:
++    try:
++        return path.read_text(encoding="utf-8")
++    except FileNotFoundError:
++        print(f"Missing file: {path}", file=sys.stderr)
++        raise
++
++
++def extract_registry_types(text: str) -> list[str]:
++    start = text.find("k_specs[]")
++    if start == -1:
++        return []
++    brace_start = text.find("{", start)
++    if brace_start == -1:
++        return []
++    end = text.find("};", brace_start)
++    if end == -1:
++        end = len(text)
++    block = text[brace_start:end]
++    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
++    return pattern.findall(block)
++
++
++def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
++    start = text.find(start_token)
++    if start == -1:
++        return ""
++    end = len(text)
++    for token in end_tokens:
++        idx = text.find(token, start + len(start_token))
++        if idx != -1:
++            end = min(end, idx)
++    return text[start:end]
++
++
++def extract_type_conditions(section: str) -> set[str]:
++    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
++
++
++def main() -> int:
++    root = Path(__file__).resolve().parents[1]
++    registry_path = root / "app" / "window_type_registry.cpp"
++    app_path = root / "app" / "test_pattern_app.cpp"
++
++    registry_text = read_text(registry_path)
++    app_text = read_text(app_path)
++
++    registry_types = extract_registry_types(registry_text)
++
++    build_section = extract_section(
++        app_text,
++        "std::string TTestPatternApp::buildWorkspaceJson",
++        ["void TTestPatternApp::saveWorkspace"],
++    )
++    restore_section = extract_section(
++        app_text,
++        "bool TTestPatternApp::loadWorkspaceFromFile",
++        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
++    )
++
++    save_types = extract_type_conditions(build_section)
++    restore_types = extract_type_conditions(restore_section)
++
++    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
++    reg_width = len("REGISTRY")
++    save_width = len("SAVE")
++    restore_width = len("RESTORE")
++
++    header = (
++        f"{'TYPE':<{type_width}}  "
++        f"{'REGISTRY':<{reg_width}}  "
++        f"{'SAVE':<{save_width}}  "
++        f"{'RESTORE':<{restore_width}}  "
++        "STATUS"
++    )
++    print(header)
++
++    has_gap = False
++    for type_name in registry_types:
++        reg_cell = "✅"
++        if type_name in STATELESS_TYPES:
++            save_cell = "—"
++            restore_cell = "—"
++            status = "stateless"
++        else:
++            save_ok = type_name in save_types
++            restore_ok = type_name in restore_types
++            save_cell = "✅" if save_ok else "❌"
++            restore_cell = "✅" if restore_ok else "❌"
++            status = "ok" if save_ok and restore_ok else "GAP"
++            if status == "GAP":
++                has_gap = True
++
++        print(
++            f"{type_name:<{type_width}}  "
++            f"{reg_cell:<{reg_width}}  "
++            f"{save_cell:<{save_width}}  "
++            f"{restore_cell:<{restore_width}}  "
++            f"{status}"
++        )
++
++    return 1 if has_gap else 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+
+
+thinking
+**Running parity-check tests**
+exec
+python3 scripts/parity-check.py in /Users/james/Repos/wibandwob-dos exited 1 in 60ms:
+TYPE               REGISTRY  SAVE  RESTORE  STATUS
+test_pattern       ✅         —     —        stateless
+gradient           ✅         —     —        stateless
+frame_player       ✅         ✅     ✅        ok
+text_view          ✅         ❌     ✅        GAP
+text_editor        ✅         —     —        stateless
+browser            ✅         —     —        stateless
+verse              ✅         —     —        stateless
+mycelium           ✅         —     —        stateless
+orbit              ✅         —     —        stateless
+torus              ✅         —     —        stateless
+cube               ✅         —     —        stateless
+life               ✅         —     —        stateless
+blocks             ✅         —     —        stateless
+score              ✅         —     —        stateless
+ascii              ✅         —     —        stateless
+animated_gradient  ✅         —     —        stateless
+monster_cam        ✅         —     —        stateless
+monster_verse      ✅         —     —        stateless
+monster_portal     ✅         —     —        stateless
+file update:
+diff --git a/scripts/parity-check.py b/scripts/parity-check.py
+new file mode 100755
+index 0000000000000000000000000000000000000000..77a717805c20a1ec4837f931274706cf49bf661f
+--- /dev/null
++++ b/scripts/parity-check.py
+@@ -0,0 +1,146 @@
++#!/usr/bin/env python3
++
++from __future__ import annotations
++
++import re
++import sys
++from pathlib import Path
++
++
++STATELESS_TYPES = {
++    "terminal",
++    "browser",
++    "scramble",
++    "quadra",
++    "snake",
++    "rogue",
++    "deep_signal",
++    "app_launcher",
++    "wibwob",
++    "orbit",
++    "torus",
++    "cube",
++    "life",
++    "blocks",
++    "score",
++    "ascii",
++    "animated_gradient",
++    "monster_cam",
++    "monster_verse",
++    "monster_portal",
++    "paint",
++    "micropolis_ascii",
++    "mycelium",
++    "verse",
++    "text_editor",
++    "test_pattern",
++    "gradient",
++}
++
++
++def read_text(path: Path) -> str:
++    try:
++        return path.read_text(encoding="utf-8")
++    except FileNotFoundError:
++        print(f"Missing file: {path}", file=sys.stderr)
++        raise
++
++
++def extract_registry_types(text: str) -> list[str]:
++    start = text.find("k_specs[]")
++    if start == -1:
++        return []
++    brace_start = text.find("{", start)
++    if brace_start == -1:
++        return []
++    end = text.find("};", brace_start)
++    if end == -1:
++        end = len(text)
++    block = text[brace_start:end]
++    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
++    return pattern.findall(block)
++
++
++def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
++    start = text.find(start_token)
++    if start == -1:
++        return ""
++    end = len(text)
++    for token in end_tokens:
++        idx = text.find(token, start + len(start_token))
++        if idx != -1:
++            end = min(end, idx)
++    return text[start:end]
++
++
++def extract_type_conditions(section: str) -> set[str]:
++    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
++
++
++def main() -> int:
++    root = Path(__file__).resolve().parents[1]
++    registry_path = root / "app" / "window_type_registry.cpp"
++    app_path = root / "app" / "test_pattern_app.cpp"
++
++    registry_text = read_text(registry_path)
++    app_text = read_text(app_path)
++
++    registry_types = extract_registry_types(registry_text)
++
++    build_section = extract_section(
++        app_text,
++        "std::string TTestPatternApp::buildWorkspaceJson",
++        ["void TTestPatternApp::saveWorkspace"],
++    )
++    restore_section = extract_section(
++        app_text,
++        "bool TTestPatternApp::loadWorkspaceFromFile",
++        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
++    )
++
++    save_types = extract_type_conditions(build_section)
++    restore_types = extract_type_conditions(restore_section)
++
++    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
++    reg_width = len("REGISTRY")
++    save_width = len("SAVE")
++    restore_width = len("RESTORE")
++
++    header = (
++        f"{'TYPE':<{type_width}}  "
++        f"{'REGISTRY':<{reg_width}}  "
++        f"{'SAVE':<{save_width}}  "
++        f"{'RESTORE':<{restore_width}}  "
++        "STATUS"
++    )
++    print(header)
++
++    has_gap = False
++    for type_name in registry_types:
++        reg_cell = "✅"
++        if type_name in STATELESS_TYPES:
++            save_cell = "—"
++            restore_cell = "—"
++            status = "stateless"
++        else:
++            save_ok = type_name in save_types
++            restore_ok = type_name in restore_types
++            save_cell = "✅" if save_ok else "❌"
++            restore_cell = "✅" if restore_ok else "❌"
++            status = "ok" if save_ok and restore_ok else "GAP"
++            if status == "GAP":
++                has_gap = True
++
++        print(
++            f"{type_name:<{type_width}}  "
++            f"{reg_cell:<{reg_width}}  "
++            f"{save_cell:<{save_width}}  "
++            f"{restore_cell:<{restore_width}}  "
++            f"{status}"
++        )
++
++    return 1 if has_gap else 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+
+
+thinking
+**Investigating mismatch in text_view state handling**
+
+The test expects exit 0 on a clean repo, but text_view appears in the registry and restore paths without being in the stateless list or the buildWorkspaceJson save handling, indicating a gap. Next I'll check if text_view is actually saved or if our detection missed it due to type checking differences.
+exec
+rg -n -C3 text_view app/test_pattern_app.cpp in /Users/james/Repos/wibandwob-dos succeeded in 20ms:
+78-// Custom frame for windows without titles
+79-#include "notitle_frame.h"
+80-// Transparent background text view
+81:#include "transparent_text_view.h"
+82-// TUI Browser window
+83-#include "browser_view.h"
+84-// Scramble cat presence
+--
+847-    friend void api_spawn_test(TTestPatternApp&);
+848-    friend void api_spawn_gradient(TTestPatternApp&, const std::string&);
+849-    friend void api_open_animation_path(TTestPatternApp&, const std::string&);
+850:    friend void api_open_text_view_path(TTestPatternApp&, const std::string&, const TRect* bounds);
+851-    friend void api_spawn_test(TTestPatternApp&, const TRect* bounds);
+852-    friend void api_spawn_gradient(TTestPatternApp&, const std::string&, const TRect* bounds);
+853-    friend void api_open_animation_path(TTestPatternApp&, const std::string&, const TRect* bounds, bool frameless, bool shadowless, const std::string& title);
+--
+2657-    }
+2658-}
+2659-
+2660:void api_open_text_view_path(TTestPatternApp& app, const std::string& path, const TRect* bounds) {
+file update:
+diff --git a/scripts/parity-check.py b/scripts/parity-check.py
+new file mode 100755
+index 0000000000000000000000000000000000000000..77a717805c20a1ec4837f931274706cf49bf661f
+--- /dev/null
++++ b/scripts/parity-check.py
+@@ -0,0 +1,146 @@
++#!/usr/bin/env python3
++
++from __future__ import annotations
++
++import re
++import sys
++from pathlib import Path
++
++
++STATELESS_TYPES = {
++    "terminal",
++    "browser",
++    "scramble",
++    "quadra",
++    "snake",
++    "rogue",
++    "deep_signal",
++    "app_launcher",
++    "wibwob",
++    "orbit",
++    "torus",
++    "cube",
++    "life",
++    "blocks",
++    "score",
++    "ascii",
++    "animated_gradient",
++    "monster_cam",
++    "monster_verse",
++    "monster_portal",
++    "paint",
++    "micropolis_ascii",
++    "mycelium",
++    "verse",
++    "text_editor",
++    "test_pattern",
++    "gradient",
++}
++
++
++def read_text(path: Path) -> str:
++    try:
++        return path.read_text(encoding="utf-8")
++    except FileNotFoundError:
++        print(f"Missing file: {path}", file=sys.stderr)
++        raise
++
++
++def extract_registry_types(text: str) -> list[str]:
++    start = text.find("k_specs[]")
++    if start == -1:
++        return []
++    brace_start = text.find("{", start)
++    if brace_start == -1:
++        return []
++    end = text.find("};", brace_start)
++    if end == -1:
++        end = len(text)
++    block = text[brace_start:end]
++    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
++    return pattern.findall(block)
++
++
++def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
++    start = text.find(start_token)
++    if start == -1:
++        return ""
++    end = len(text)
++    for token in end_tokens:
++        idx = text.find(token, start + len(start_token))
++        if idx != -1:
++            end = min(end, idx)
++    return text[start:end]
++
++
++def extract_type_conditions(section: str) -> set[str]:
++    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
++
++
++def main() -> int:
++    root = Path(__file__).resolve().parents[1]
++    registry_path = root / "app" / "window_type_registry.cpp"
++    app_path = root / "app" / "test_pattern_app.cpp"
++
++    registry_text = read_text(registry_path)
++    app_text = read_text(app_path)
++
++    registry_types = extract_registry_types(registry_text)
++
++    build_section = extract_section(
++        app_text,
++        "std::string TTestPatternApp::buildWorkspaceJson",
++        ["void TTestPatternApp::saveWorkspace"],
++    )
++    restore_section = extract_section(
++        app_text,
++        "bool TTestPatternApp::loadWorkspaceFromFile",
++        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
++    )
++
++    save_types = extract_type_conditions(build_section)
++    restore_types = extract_type_conditions(restore_section)
++
++    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
++    reg_width = len("REGISTRY")
++    save_width = len("SAVE")
++    restore_width = len("RESTORE")
++
++    header = (
++        f"{'TYPE':<{type_width}}  "
++        f"{'REGISTRY':<{reg_width}}  "
++        f"{'SAVE':<{save_width}}  "
++        f"{'RESTORE':<{restore_width}}  "
++        "STATUS"
++    )
++    print(header)
++
++    has_gap = False
++    for type_name in registry_types:
++        reg_cell = "✅"
++        if type_name in STATELESS_TYPES:
++            save_cell = "—"
++            restore_cell = "—"
++            status = "stateless"
++        else:
++            save_ok = type_name in save_types
++            restore_ok = type_name in restore_types
++            save_cell = "✅" if save_ok else "❌"
++            restore_cell = "✅" if restore_ok else "❌"
++            status = "ok" if save_ok and restore_ok else "GAP"
++            if status == "GAP":
++                has_gap = True
++
++        print(
++            f"{type_name:<{type_width}}  "
++            f"{reg_cell:<{reg_width}}  "
++            f"{save_cell:<{save_width}}  "
++            f"{restore_cell:<{restore_width}}  "
++            f"{status}"
++        )
++
++    return 1 if has_gap else 0
++
++
++if __name__ == "__main__":
++    sys.exit(main())
+
+
+
+

--- a/app/test_pattern_app.cpp
+++ b/app/test_pattern_app.cpp
@@ -1985,7 +1985,8 @@ void TTestPatternApp::newDonutWindow()
     );
     
     // Create and insert window with donut.txt file (no title for minimalist aesthetic)
-    TFrameAnimationWindow* window = new TFrameAnimationWindow(bounds, "", "donut.txt");
+    // Path is relative to repo root (CWD when launched via ./build/app/test_pattern)
+    TFrameAnimationWindow* window = new TFrameAnimationWindow(bounds, "", "app/donut.txt");
     deskTop->insert(window);
     registerWindow(window);
 }
@@ -3290,7 +3291,7 @@ bool TTestPatternApp::loadWorkspaceFromFile(const std::string& path)
                     if (!pmsStr.empty()) pms = (unsigned)std::stoul(pmsStr);
                 }
             }
-            if (!path.empty()) openAnimationFilePath(path, bounds, false, false);
+            if (!path.empty()) openAnimationFilePath(path, bounds, false, false, title);
             continue; // openAnimationFilePath handles insert + register
         } else if (type == "text_view") {
             std::string path;
@@ -3520,6 +3521,12 @@ std::string TTestPatternApp::buildWorkspaceJson()
                 c = c->next;
             } while (c != cStart);
             }
+        } else if (type == "text_view") {
+            if (auto *ttw = dynamic_cast<TTransparentTextWindow*>(w)) {
+                const std::string& fp = ttw->getFilePath();
+                if (!fp.empty())
+                    props = "{\"path\": \"" + jsonEscape(fp) + "\"}";
+            }
         } else if (type == "gallery") {
             if (auto *gallery = dynamic_cast<TGalleryWindow*>(w)) {
                 props = std::string("{\"tab\": ") + std::to_string(gallery->getSelected());
@@ -3546,7 +3553,24 @@ std::string TTestPatternApp::buildWorkspaceJson()
         json += "      \"id\": \"w" + std::to_string(idx) + "\",\n";
         json += "      \"type\": \"" + type + "\",\n";
         const char *title = w->getTitle(0);
-        std::string safeTitle = title ? jsonEscape(title) : std::string("");
+        std::string titleValue;
+        if (title && *title) {
+            titleValue = title;
+        } else if (type == "frame_player") {
+            if (auto *faw = dynamic_cast<TFrameAnimationWindow*>(w)) {
+                const std::string& fp = faw->getFilePath();
+                if (!fp.empty()) {
+                    size_t slash = fp.find_last_of("/\\");
+                    size_t start = (slash == std::string::npos) ? 0 : slash + 1;
+                    std::string base = fp.substr(start);
+                    size_t dot = base.find_last_of('.');
+                    if (dot != std::string::npos && dot != 0)
+                        base = base.substr(0, dot);
+                    titleValue = base;
+                }
+            }
+        }
+        std::string safeTitle = jsonEscape(titleValue);
         json += "      \"title\": \"" + safeTitle + "\",\n";
         json += "      \"bounds\": { \"x\": " + std::to_string(x) + ", \"y\": " + std::to_string(y) + ", \"w\": " + std::to_string(ww) + ", \"h\": " + std::to_string(hh) + " },\n";
         json += std::string("      \"zoomed\": ") + (zoomed ? "true" : "false") + ",\n";

--- a/scripts/parity-check.py
+++ b/scripts/parity-check.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+STATELESS_TYPES = {
+    "terminal",
+    "browser",
+    "scramble",
+    "quadra",
+    "snake",
+    "rogue",
+    "deep_signal",
+    "app_launcher",
+    "wibwob",
+    "orbit",
+    "torus",
+    "cube",
+    "life",
+    "blocks",
+    "score",
+    "ascii",
+    "animated_gradient",
+    "monster_cam",
+    "monster_verse",
+    "monster_portal",
+    "paint",
+    "micropolis_ascii",
+    "mycelium",
+    "verse",
+    "text_editor",
+    "test_pattern",
+    "gradient",
+}
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(f"Missing file: {path}", file=sys.stderr)
+        raise
+
+
+def extract_registry_types(text: str) -> list[str]:
+    start = text.find("k_specs[]")
+    if start == -1:
+        return []
+    brace_start = text.find("{", start)
+    if brace_start == -1:
+        return []
+    end = text.find("};", brace_start)
+    if end == -1:
+        end = len(text)
+    block = text[brace_start:end]
+    pattern = re.compile(r"\{\s*\"([^\"]+)\"\s*,")
+    return pattern.findall(block)
+
+
+def extract_section(text: str, start_token: str, end_tokens: list[str]) -> str:
+    start = text.find(start_token)
+    if start == -1:
+        return ""
+    end = len(text)
+    for token in end_tokens:
+        idx = text.find(token, start + len(start_token))
+        if idx != -1:
+            end = min(end, idx)
+    return text[start:end]
+
+
+def extract_type_conditions(section: str) -> set[str]:
+    return set(re.findall(r"type\s*==\s*\"([^\"]+)\"", section))
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    registry_path = root / "app" / "window_type_registry.cpp"
+    app_path = root / "app" / "test_pattern_app.cpp"
+
+    registry_text = read_text(registry_path)
+    app_text = read_text(app_path)
+
+    registry_types = extract_registry_types(registry_text)
+
+    build_section = extract_section(
+        app_text,
+        "std::string TTestPatternApp::buildWorkspaceJson",
+        ["void TTestPatternApp::saveWorkspace"],
+    )
+    restore_section = extract_section(
+        app_text,
+        "bool TTestPatternApp::loadWorkspaceFromFile",
+        ["void TTestPatternApp::loadWorkspace", "bool TTestPatternApp::openWorkspacePath"],
+    )
+
+    save_types = extract_type_conditions(build_section)
+    restore_types = extract_type_conditions(restore_section)
+
+    type_width = max(len("TYPE"), *(len(t) for t in registry_types)) if registry_types else len("TYPE")
+    reg_width = len("REGISTRY")
+    save_width = len("SAVE")
+    restore_width = len("RESTORE")
+
+    header = (
+        f"{'TYPE':<{type_width}}  "
+        f"{'REGISTRY':<{reg_width}}  "
+        f"{'SAVE':<{save_width}}  "
+        f"{'RESTORE':<{restore_width}}  "
+        "STATUS"
+    )
+    print(header)
+
+    has_gap = False
+    for type_name in registry_types:
+        reg_cell = "✅"
+        if type_name in STATELESS_TYPES:
+            save_cell = "—"
+            restore_cell = "—"
+            status = "stateless"
+        else:
+            save_ok = type_name in save_types
+            restore_ok = type_name in restore_types
+            save_cell = "✅" if save_ok else "❌"
+            restore_cell = "✅" if restore_ok else "❌"
+            status = "ok" if save_ok and restore_ok else "GAP"
+            if status == "GAP":
+                has_gap = True
+
+        print(
+            f"{type_name:<{type_width}}  "
+            f"{reg_cell:<{reg_width}}  "
+            f"{save_cell:<{save_width}}  "
+            f"{restore_cell:<{restore_width}}  "
+            f"{status}"
+        )
+
+    return 1 if has_gap else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #84, closes #86

## What
- **AC-11/12**: frame_player titles now derived from filename stem on save (`cat-in-space.txt` → `title: 'cat-in-space'`). Passed to `openAnimationFilePath` on restore.
- **F06**: `scripts/parity-check.py` — reads C++ source, prints gap matrix, exits non-zero on any missing save/restore coverage. Caught a real gap (text_view save missing) on first run.
- **text_view save**: bonus fix — `buildWorkspaceJson` now emits `{path}` props for text_view windows.

## Verified
- `chaos.txt` → `title='chaos'` ✅
- `cat-in-space.txt` → `title='cat-in-space'` ✅  
- `python3 scripts/parity-check.py` → all ok, exit 0 ✅