### PR TITLE
fix(scramble): input text wraps/scrolls instead of cropping

### DIFF
--- a/.pi/skills/ghostty-control/SKILL.md
+++ b/.pi/skills/ghostty-control/SKILL.md
@@ -41,6 +41,7 @@ bash .pi/skills/ghostty-control/scripts/click-cell.sh 75 36 --single
 bash .pi/skills/ghostty-control/scripts/send-to-terminal.sh wibandwob-dos "bun run dev"
 bash .pi/skills/ghostty-control/scripts/wait-for.sh health
 bash .pi/skills/ghostty-control/scripts/wait-for.sh window "Figlet" --timeout 5
+bash .pi/skills/ghostty-control/scripts/open-instance.sh --worktree cga-theme --theme wibwob-cga
 eval "$(bash .pi/skills/ghostty-control/scripts/calibrate.sh)"
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ CAPS `.md` at root = sole doc surface. Don't create docs elsewhere.
 
 ## Orient fast
 ```
-ls *.md          # PHILOSOPHY ARCHITECTURE GOTCHAS SDK-MICROAPP-DEV
-cat .pi/skills/skills.md
+ls *.md | grep '^[A-Z-]*\.md$'   # CAPS doc surface only
 wibwob health                         # instance, port, screen, uptime
 bash scripts/devlog-open.sh   # open ideas + unresolved pains this week
 ```

--- a/src/windows/scramble-window.ts
+++ b/src/windows/scramble-window.ts
@@ -223,7 +223,9 @@ export function openScrambleFloatingWindow(deps: ScrambleFloatingDeps): void {
   const MAX_INPUT_ROWS = 4;
 
   const renderInputEl = () => {
-    const width = Math.max(1, Number(inputEl.width) || 1);
+    const raw = Number(inputEl.width);
+    if (!raw || raw < 4) { screen.render(); return; } // not laid out yet — skip
+    const width = raw;
     const cursor = inputEl === screen.focused ? "█" : " ";
     const full = getDraft() + cursor;
     const rows: string[] = [];
@@ -468,7 +470,8 @@ export function openScrambleSmolPopup(deps: ScrambleSmolDeps): void {
   const { getDraft } = wireInput(screen, inputEl, () => {
     const width = Math.max(1, Number(inputEl.width) || 1);
     const full = getDraft() + "_";
-    inputEl.setContent(full.slice(0, width).padEnd(width, " "));
+    // Show the tail so the cursor is always visible — scrolling-input behaviour
+    inputEl.setContent(full.slice(Math.max(0, full.length - width)).padEnd(width, " "));
   }, (text) => {
     void brain.send(text).then(() => {
       renderCat();


### PR DESCRIPTION
## Bugs

**Smol popup hard-cropped input**
`full.slice(0, width)` — text past the edge was silently lost from view.
Fix: `full.slice(full.length - width)` — shows the tail, cursor stays visible, text scrolls left.

**Floating window pre-render width=1**
`Math.max(1, Number(inputEl.width) || 1)` before first `screen.render()` returned 1.
Every character got its own row → input ballooned to 4 rows on load.
Fix: bail early if width < 4 (not laid out yet), retry on next keypress with real dimensions.